### PR TITLE
librs: add ioctl syscall support

### DIFF
--- a/src/pthread.rs
+++ b/src/pthread.rs
@@ -447,7 +447,7 @@ pub extern "C" fn pthread_setspecific(key: pthread_key_t, val: *const c_void) ->
     }
     let tid = pthread_self();
     let Some(tcb) = get_tcb(tid) else {
-        panic!("{:x}: My tcb is gone!", tid)
+        return EINVAL;
     };
     tcb.kv.write().insert(key, val as usize);
     0
@@ -461,7 +461,7 @@ pub extern "C" fn pthread_getspecific(key: pthread_key_t) -> *mut c_void {
     }
     let tid = pthread_self();
     let Some(tcb) = get_tcb(tid) else {
-        panic!("0x{:x}: My tcb is gone!", tid)
+        return core::ptr::null_mut();
     };
     {
         let read_tcb_kv = tcb.kv.read();

--- a/src/syscall/blueos/mod.rs
+++ b/src/syscall/blueos/mod.rs
@@ -20,14 +20,14 @@ use crate::{
 };
 use blueos_header::syscalls::NR::{
     Accept, Bind, Chdir, ClockGetTime, ClockNanoSleep, Close, Connect, FStat, Fcntl, FreeAddrinfo,
-    Ftruncate, GetAddrinfo, GetDents, Getcwd, Getsockopt, Link, Listen, Lseek, Mkdir, Open, Read,
-    Recv, Recvfrom, Recvmsg, Rmdir, Send, Sendmsg, Sendto, Setsockopt, Shutdown, Socket, Statfs,
-    Unlink, Write,
+    Ftruncate, GetAddrinfo, GetDents, Getcwd, Getsockopt, Ioctl, Link, Listen, Lseek, Mkdir, Open,
+    Read, Recv, Recvfrom, Recvmsg, Rmdir, Send, Sendmsg, Sendto, Setsockopt, Shutdown, Socket,
+    Statfs, Unlink, Write,
 };
 use blueos_scal::bk_syscall;
 use libc::{
-    c_char, c_int, c_uint, c_void, clockid_t, dev_t, mode_t, msghdr, off_t, size_t, sockaddr,
-    socklen_t, ssize_t, statvfs, timespec, utsname,
+    c_char, c_int, c_uint, c_ulong, c_void, clockid_t, dev_t, mode_t, msghdr, off_t, size_t,
+    sockaddr, socklen_t, ssize_t, statvfs, timespec, utsname,
 };
 
 // convert value returned by syscall to user Result.
@@ -434,5 +434,10 @@ impl Syscall for Sys {
     unsafe fn freeaddrinfo(res: *mut libc::addrinfo) -> Result<()> {
         bk_syscall!(FreeAddrinfo, res);
         Ok(())
+    }
+
+    unsafe fn ioctl(fd: c_int, request: c_ulong, arg: *mut c_void) -> Result<c_int> {
+        to_result(bk_syscall!(Ioctl, fd, request, arg as *mut core::ffi::c_void) as usize)
+            .map(|r| r as c_int)
     }
 }

--- a/src/syscall/linux_emulation/consts.rs
+++ b/src/syscall/linux_emulation/consts.rs
@@ -85,3 +85,5 @@ pub const SYS_RECVMSG: i32 = 297;
 
 pub const SYS_GETADDRINFO: i32 = 298;
 pub const SYS_FREEADDRINFO: i32 = 299;
+
+pub const SYS_IOCTL: i32 = 54;

--- a/src/syscall/linux_emulation/mod.rs
+++ b/src/syscall/linux_emulation/mod.rs
@@ -21,8 +21,8 @@ use crate::{
 };
 use blueos_scal::bk_syscall;
 use libc::{
-    c_char, c_int, c_uint, c_void, clockid_t, dev_t, mode_t, msghdr, off_t, size_t, sockaddr,
-    socklen_t, ssize_t, statvfs, timespec, utsname, EINVAL, S_IFIFO,
+    c_char, c_int, c_uint, c_ulong, c_void, clockid_t, dev_t, mode_t, msghdr, off_t, size_t,
+    sockaddr, socklen_t, ssize_t, statvfs, timespec, utsname, EINVAL, S_IFIFO,
 };
 pub mod consts;
 
@@ -429,5 +429,9 @@ impl Syscall for Sys {
 
     unsafe fn freeaddrinfo(res: *mut libc::addrinfo) -> Result<()> {
         to_result(bk_syscall!(SYS_FREEADDRINFO, res))
+    }
+
+    unsafe fn ioctl(fd: c_int, request: c_ulong, arg: *mut c_void) -> Result<c_int> {
+        to_result(bk_syscall!(SYS_IOCTL, fd, request, arg)).map(|r| r as c_int)
     }
 }

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -14,8 +14,8 @@
 
 use crate::{c_str::CStr, errno::Result, mqueue::mq_attr};
 use libc::{
-    addrinfo, c_char, c_int, c_uint, c_void, clockid_t, dev_t, mode_t, msghdr, off_t, size_t,
-    sockaddr, socklen_t, ssize_t, statvfs, timespec, utsname,
+    addrinfo, c_char, c_int, c_uint, c_ulong, c_void, clockid_t, dev_t, mode_t, msghdr, off_t,
+    size_t, sockaddr, socklen_t, ssize_t, statvfs, timespec, utsname,
 };
 
 pub trait Syscall {
@@ -154,6 +154,7 @@ pub trait Syscall {
         res: *mut *mut addrinfo,
     ) -> Result<c_int>;
     unsafe fn freeaddrinfo(res: *mut addrinfo) -> Result<()>;
+    unsafe fn ioctl(fd: c_int, request: c_ulong, arg: *mut c_void) -> Result<c_int>;
 }
 
 pub use self::sys::Sys;


### PR DESCRIPTION
## Summary
- add ioctl syscall plumbing for BlueOS and linux emulation backends
- expose ioctl in the shared Syscall trait
- return errors instead of panicking when pthread-specific TCB state is missing

## Affected board/arch
- qemu_riscv64

## Tests
- `export PATH="/home/xuchang/.rustup/toolchains/blueos-latest/bin:$PATH"`
- `rustfmt --edition 2021 src/pthread.rs src/syscall/blueos/mod.rs src/syscall/linux_emulation/consts.rs src/syscall/linux_emulation/mod.rs src/syscall/mod.rs`
- `ninja -C out/qemu_riscv64 check_all` (log reached `Kernel integration test end.`; initial harness exit was non-zero with no Rust compile errors in the captured failure context)

## Notes
- No doc or config updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)