### PR TITLE
Fix free is empty function in release

### DIFF
--- a/src/stdlib/malloc.rs
+++ b/src/stdlib/malloc.rs
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn posix_memalign(
 
 #[no_mangle]
 pub unsafe extern "C" fn free(ptr: *mut c_void) {
-    debug_assert_eq!(bk_syscall!(FreeMem, ptr), 0);
+    bk_syscall!(FreeMem, ptr);
 }
 
 #[no_mangle]


### PR DESCRIPTION
Remove the use of `debug_assert_eq` to allow its use in release builds. Meanwhile, in `kernel/kernel/src/syscall_handlers/mod.rs`, the function looks like this: 
```rust
define_syscall_handler!( 
    free_mem(ptr: *mut c_void) -> c_long { 
        crate::allocator::free(ptr as *mut u8);
        0 
});
```
 This assertion is meaningless.