### PR TITLE
librs: translate socket syscall errors to errno

### DIFF
--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::errno::ERRNO;
 pub use blueos_header::syscalls::NR::{
     Accept, Bind, Connect, Getsockopt, Listen, Recv, Recvfrom, Recvmsg, Send, Sendmsg, Sendto,
     Setsockopt, Shutdown, Socket,
 };
 use blueos_scal::bk_syscall;
-use crate::errno::ERRNO;
 use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
 
 #[inline]
@@ -166,8 +166,9 @@ pub unsafe extern "C" fn sendto(
     dest_addr: *const libc::sockaddr,
     dest_len: libc::socklen_t,
 ) -> c_ssize_t {
-    syscall_result(bk_syscall!(Sendto, socket, message, length, flags, dest_addr, dest_len) as isize)
-        as c_ssize_t
+    syscall_result(
+        bk_syscall!(Sendto, socket, message, length, flags, dest_addr, dest_len) as isize,
+    ) as c_ssize_t
 }
 
 /// Receive message from socket

--- a/src/net/socket.rs
+++ b/src/net/socket.rs
@@ -17,7 +17,18 @@ pub use blueos_header::syscalls::NR::{
     Setsockopt, Shutdown, Socket,
 };
 use blueos_scal::bk_syscall;
+use crate::errno::ERRNO;
 use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
+
+#[inline]
+fn syscall_result(result: isize) -> isize {
+    if result < 0 {
+        ERRNO.set((-result) as c_int);
+        -1
+    } else {
+        result
+    }
+}
 
 /// Creates a new communication endpoint
 ///
@@ -31,7 +42,7 @@ use core::ffi::{c_int, c_size_t, c_ssize_t, c_void};
 /// <https://pubs.opengroup.org/onlinepubs/9799919799/functions/socket.html>
 #[no_mangle]
 pub extern "C" fn socket(domain: c_int, type_: c_int, protocol: c_int) -> c_int {
-    bk_syscall!(Socket, domain, type_, protocol) as c_int
+    syscall_result(bk_syscall!(Socket, domain, type_, protocol) as isize) as c_int
 }
 
 /// Bind socket to local address
@@ -50,7 +61,7 @@ pub unsafe extern "C" fn bind(
     address: *const libc::sockaddr,
     address_len: libc::socklen_t,
 ) -> c_int {
-    bk_syscall!(Bind, socket, address, address_len) as c_int
+    syscall_result(bk_syscall!(Bind, socket, address, address_len) as isize) as c_int
 }
 
 /// Connect socket to remote address
@@ -69,7 +80,7 @@ pub unsafe extern "C" fn connect(
     address: *const libc::sockaddr,
     address_len: libc::socklen_t,
 ) -> c_int {
-    bk_syscall!(Connect, socket, address, address_len) as c_int
+    syscall_result(bk_syscall!(Connect, socket, address, address_len) as isize) as c_int
 }
 
 /// Listen for socket connections
@@ -87,7 +98,7 @@ pub unsafe extern "C" fn connect(
 /// <https://pubs.opengroup.org/onlinepubs/9799919799/functions/listen.html>
 #[no_mangle]
 pub extern "C" fn listen(socket: c_int, backlog: c_int) -> c_int {
-    bk_syscall!(Listen, socket, backlog) as c_int
+    syscall_result(bk_syscall!(Listen, socket, backlog) as isize) as c_int
 }
 
 /// Accept incoming connection
@@ -106,7 +117,7 @@ pub unsafe extern "C" fn accept(
     _address: *mut libc::sockaddr,
     _address_len: *mut libc::socklen_t,
 ) -> c_int {
-    bk_syscall!(Accept, sock_fd, _address, _address_len) as c_int
+    syscall_result(bk_syscall!(Accept, sock_fd, _address, _address_len) as isize) as c_int
 }
 
 /// Send message through socket
@@ -128,7 +139,7 @@ pub unsafe extern "C" fn send(
     length: c_size_t,
     flags: c_int,
 ) -> c_ssize_t {
-    bk_syscall!(Send, socket, buffer, length, flags) as c_ssize_t
+    syscall_result(bk_syscall!(Send, socket, buffer, length, flags) as isize) as c_ssize_t
 }
 
 /// Send message through socket
@@ -155,7 +166,8 @@ pub unsafe extern "C" fn sendto(
     dest_addr: *const libc::sockaddr,
     dest_len: libc::socklen_t,
 ) -> c_ssize_t {
-    bk_syscall!(Sendto, socket, message, length, flags, dest_addr, dest_len) as c_ssize_t
+    syscall_result(bk_syscall!(Sendto, socket, message, length, flags, dest_addr, dest_len) as isize)
+        as c_ssize_t
 }
 
 /// Receive message from socket
@@ -177,7 +189,7 @@ pub unsafe extern "C" fn recv(
     length: c_size_t,
     flags: c_int,
 ) -> c_ssize_t {
-    bk_syscall!(Recv, socket, buffer, length, flags) as c_ssize_t
+    syscall_result(bk_syscall!(Recv, socket, buffer, length, flags) as isize) as c_ssize_t
 }
 
 /// Recv a message from a socket
@@ -206,7 +218,7 @@ pub unsafe extern "C" fn recvfrom(
     address: *mut libc::sockaddr,
     address_len: *mut libc::socklen_t,
 ) -> c_ssize_t {
-    bk_syscall!(
+    syscall_result(bk_syscall!(
         Recvfrom,
         socket,
         buffer,
@@ -214,7 +226,7 @@ pub unsafe extern "C" fn recvfrom(
         flags,
         address,
         address_len
-    ) as c_ssize_t
+    ) as isize) as c_ssize_t
 }
 
 /// Shutdown socket communication
@@ -229,7 +241,7 @@ pub unsafe extern "C" fn recvfrom(
 /// <https://pubs.opengroup.org/onlinepubs/9799919799/functions/shutdown.html>
 #[no_mangle]
 pub extern "C" fn shutdown(socket: c_int, how: c_int) -> c_int {
-    bk_syscall!(Shutdown, socket, how) as c_int
+    syscall_result(bk_syscall!(Shutdown, socket, how) as isize) as c_int
 }
 
 /// Set the socket options
@@ -252,14 +264,14 @@ pub unsafe extern "C" fn setsockopt(
     option_value: *const c_void,
     option_len: libc::socklen_t,
 ) -> c_int {
-    bk_syscall!(
+    syscall_result(bk_syscall!(
         Setsockopt,
         socket,
         level,
         option_name,
         option_value,
         option_len
-    ) as c_int
+    ) as isize) as c_int
 }
 
 /// get the socket options
@@ -282,14 +294,14 @@ pub unsafe extern "C" fn getsockopt(
     option_value: *mut c_void,
     option_len: *mut libc::socklen_t,
 ) -> c_int {
-    bk_syscall!(
+    syscall_result(bk_syscall!(
         Getsockopt,
         socket,
         level,
         option_name,
         option_value,
         option_len
-    ) as c_int
+    ) as isize) as c_int
 }
 
 /// Send message through socket
@@ -311,7 +323,7 @@ pub unsafe extern "C" fn sendmsg(
     message: *const libc::msghdr,
     flags: c_int,
 ) -> c_ssize_t {
-    bk_syscall!(Sendmsg, socket, message, flags) as c_ssize_t
+    syscall_result(bk_syscall!(Sendmsg, socket, message, flags) as isize) as c_ssize_t
 }
 
 /// Recv message through socket
@@ -335,5 +347,5 @@ pub unsafe extern "C" fn recvmsg(
     message: *mut libc::msghdr,
     flags: c_int,
 ) -> c_ssize_t {
-    bk_syscall!(Recvmsg, socket, message, flags) as c_ssize_t
+    syscall_result(bk_syscall!(Recvmsg, socket, message, flags) as isize) as c_ssize_t
 }


### PR DESCRIPTION
## Summary
- Translate negative BlueOS socket syscall results into POSIX `-1` returns.
- Store the corresponding errno in the thread-local `ERRNO` cell.
- Apply the conversion consistently across socket, connection, I/O, shutdown, and socket-option wrappers.

## Motivation
BlueOS socket syscalls report failures as negative errno values. Returning those values directly from the libc wrappers violates the POSIX C ABI and causes Rust std to observe an incorrect return value and stale errno (for example, `os error 0`). This change restores the expected `-1` plus `errno` behavior.

## POSIX references
- [POSIX errno definitions](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html)
- [`setsockopt()` return value and errors](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html)
- [`socket()` return value and errors](https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html)

These interfaces specify a non-negative result on success and `-1` on failure, with `errno` set to indicate the error.

## Testing
- `git diff --check`
- No build was run.